### PR TITLE
Introduce object_utils function to convert key cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "express": "^4.16.4",
+    "lodash": "^4.17.11",
     "request": "^2.88.0",
     "underscore": "^1.9.1",
     "uuid": "^3.3.2"
@@ -53,6 +54,7 @@
     "@types/async": "^2.0.50",
     "@types/chai": "^4.1.7",
     "@types/express": "^4.16.0",
+    "@types/lodash": "^4.14.123",
     "@types/mocha": "^5.2.5",
     "@types/request": "^2.48.1",
     "@types/underscore": "^1.8.9",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,8 +48,7 @@ import * as imp_ObjectUtils from "./objects_utils";
 
 	export const HashicorpVaultProvider = imp_HashicorpVaultProvider;
 
-	export const toCamelCase = imp_ObjectUtils.toCamelCase;
-	export const toSnakeCase = imp_ObjectUtils.toSnakeCase;
+	export const ObjectUtils = imp_ObjectUtils;
 // }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {Microservice as imp_Microservice} from "./microservice";
 
 import * as imp_ServiceConfigs from "./service_configs";
 import * as imp_ServiceParams from "./service_params";
+import * as imp_ObjectUtils from "./objects_utils";
 
 
 // export namespace NodeMicroSVCLib{
@@ -46,6 +47,9 @@ import * as imp_ServiceParams from "./service_params";
 	export const PARAM_TYPES = imp_ServiceParams.PARAM_TYPES;
 
 	export const HashicorpVaultProvider = imp_HashicorpVaultProvider;
+
+	export const toCamelCase = imp_ObjectUtils.toCamelCase;
+	export const toSnakeCase = imp_ObjectUtils.toSnakeCase;
 // }
 
 

--- a/src/objects_utils.ts
+++ b/src/objects_utils.ts
@@ -1,0 +1,36 @@
+import _ from 'lodash';
+
+/**
+ * deeply converts keys of an object following converterFunction
+ * @param {object} object to convert
+ * @param {function} function to convert key.
+ * @return converted object
+ */
+const convertCase = (oldObject: any, converterFunction: any): any => {
+  let newObject;
+
+  if (
+    !oldObject ||
+    typeof oldObject !== 'object' ||
+    !Object.keys(oldObject).length
+  ) {
+    return oldObject;
+  }
+
+  if (Array.isArray(oldObject)) {
+    newObject = oldObject.map((element) =>
+      convertCase(element, converterFunction),
+    );
+  } else {
+    newObject = {};
+    Object.keys(oldObject).forEach((oldKey) => {
+      const newKey = converterFunction(oldKey);
+      newObject[newKey] = convertCase(oldObject[oldKey], converterFunction);
+    });
+  }
+
+  return newObject;
+};
+
+export const toCamelCase = (obj: any) => convertCase(obj, _.camelCase);
+export const toSnakeCase = (obj: any) => convertCase(obj, _.snakeCase);


### PR DESCRIPTION
Offers two functionalities:
- toCamelCase, to convert an object's keys to camelCase
- toSnakeCase, to convert an object's keys to snake_case