### PR TITLE
Add JSONLogger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2864,6 +2864,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "printf": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/printf/-/printf-0.5.1.tgz",
+      "integrity": "sha512-UaE/jO0hNsrvPGQEb4LyNzcrJv9Z00tsreBduOSxMtrebvoUhxiEJ4YCHX8YHf6akwfKsC2Gyv5zv47UXhMiLg=="
+    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "bunyan-prettystream": "^0.1.3",
     "express": "^4.17.0",
     "lodash": "^4.17.11",
+    "printf": "^0.5.1",
     "request": "^2.88.0",
     "underscore": "^1.9.1",
     "uuid": "^3.3.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {HashicorpVaultProvider as imp_HashicorpVaultProvider} from "./config_pro
 import {AWSSecretsManagerProvider as imp_AWSSecretsManagerProvider} from "./config_providers/aws_secrets_manager";
 import * as Interfaces from "./interfaces";
 import {ConsoleLogger as imp_ConsoleLogger} from "./console_logger";
+import {JSONLogger as imp_JSONLogger} from "./json_logger";
 import {BunyanLogger as imp_BunyanLogger} from "./bunyan_logger";
 import {DiContainer as imp_DiContainer} from "./di_container";
 import {Microservice as imp_Microservice} from "./microservice";
@@ -22,6 +23,9 @@ import * as imp_ObjectUtils from "./objects_utils";
 
 	export type ConsoleLogger = imp_ConsoleLogger;
 	export const ConsoleLogger = imp_ConsoleLogger;
+
+	export type JSONLogger = imp_JSONLogger;
+	export const JSONLogger = imp_JSONLogger;
 
 	export type BunyanLogger = imp_BunyanLogger;
 	export const BunyanLogger = imp_BunyanLogger;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,6 +3,15 @@
  */
 "use strict";
 
+export enum LogLevels {
+	TRACE =  	"TRACE",
+	DEBUG = 	"DEBUG",
+	INFO = 		"INFO",
+	WARN =		"WARN",
+	ERROR = 	"ERROR",
+	FATAL = 	"FATAL",
+}
+
 export interface ILogger {
 	debug(message?: any, ...optionalParams: any[]): void;
 	info(message?: any, ...optionalParams: any[]): void;

--- a/src/json_logger.ts
+++ b/src/json_logger.ts
@@ -1,0 +1,83 @@
+/**
+ * Created by Marten Sies on 13/June/2019.
+ */
+"use strict";
+
+import * as Bunyan from "bunyan";
+import {ILogger, LogLevels} from "./interfaces";
+import {ServiceConfigs} from "./service_configs";
+import printf = require("printf");
+
+export class JSONLogger implements ILogger {
+	private _attrs:object = {};
+	private readonly _logger:Bunyan;
+
+	constructor(svc_configs: ServiceConfigs) {
+		this._logger = Bunyan.createLogger({
+			name: svc_configs.app_name,
+			instance_id: svc_configs.instance_id,
+			env: svc_configs.env,
+			app_version: svc_configs.app_version,
+			streams: [
+				{
+					level: 'trace',
+					stream: process.stdout
+				}
+			],
+		});
+	}
+
+	debug(message?: any, ...optionalParams: any[]): void {
+		this._logger.debug.apply(this._logger,[
+			this.create_message(LogLevels.DEBUG, message, optionalParams),
+		]);
+	}
+
+	info(message?: any, ...optionalParams: any[]): void {
+		this._logger.info.apply(this._logger, [
+			this.create_message(LogLevels.INFO, message, optionalParams),
+		]);
+	}
+
+	warn(message?: any, ...optionalParams: any[]): void {
+		this._logger.warn.apply(this._logger, [
+			this.create_message(LogLevels.WARN, message, optionalParams),
+		]);
+	}
+
+	error(message?: any, ...optionalParams: any[]): void {
+		this._logger.error.apply(this._logger, [
+			this.create_message(LogLevels.ERROR, message, optionalParams),
+		]);
+	}
+
+	fatal(message?: any, ...optionalParams: any[]): void {
+		this._logger.fatal.apply(this._logger, [
+			this.create_message(LogLevels.FATAL, message, optionalParams),
+		]);
+	}
+
+	create_message(level: string, message?: any, ...optionalParams: any[]): {} {
+		let logMessage = {
+			log_level: level,
+		};
+
+		if (typeof message === "object") {
+			Object.assign(logMessage, message);
+		} else if (typeof message === "string") {
+			Object.assign(logMessage, {message: printf(message, optionalParams)});
+		} else {
+			Object.assign(logMessage, {message});
+		}
+
+		return logMessage;
+	}
+
+	create_child(attrs?: object): ILogger {
+		if(attrs)
+			this._attrs = attrs;
+
+		// @ts-ignore
+		return this._logger.child(attrs, false);
+	}
+}


### PR DESCRIPTION
Logger outputs to stdout in JSON format. The method signatures are the same as the ConsoleLogger allowing services to easily switch to the JSONLogger without any breaking changes.

Examples:
```js
const logger = new JSONLogger(serviceConfigs);

logger.debug({ correlationId: '1fb1c7c3-2751-4287-b678-00d406f37429' });
// output: {"name":"your-node-svc","instance_id":"c5ade839-73a1-47a9-8552-a9417d0b8c09","env":"development","app_version":"0.0.1","hostname":"your-hostname","pid":34452,"level":20,"log_level":"DEBUG","correlationId":"1fb1c7c3-2751-4287-b678-00d406f37429","msg":"","time":"2019-06-13T09:59:36.225Z","v":0}

logger.info({ correlationId: '1fb1c7c3-2751-4287-b678-00d406f37429', message: 'test' });
// output: {"name":"your-node-svc","instance_id":"c5ade839-73a1-47a9-8552-a9417d0b8c09","env":"development","app_version":"0.0.1","hostname":"your-hostname","pid":34452,"level":30,"log_level":"INFO","correlationId":"1fb1c7c3-2751-4287-b678-00d406f37429","message":"test","msg":"","time":"2019-06-13T09:59:36.225Z","v":0}

logger.warn('test');
// output: {"name":"your-node-svc","instance_id":"c5ade839-73a1-47a9-8552-a9417d0b8c09","env":"development","app_version":"0.0.1","hostname":"your-hostname","pid":34452,"level":40,"log_level":"WARN","message":"test","msg":"","time":"2019-06-13T09:59:36.226Z","v":0}

logger.error('test %s', 'message');
// output: {"name":"your-node-svc","instance_id":"c5ade839-73a1-47a9-8552-a9417d0b8c09","env":"development","app_version":"0.0.1","hostname":"your-hostname","pid":34452,"level":50,"log_level":"ERROR","message":"test message","msg":"","time":"2019-06-13T09:59:36.227Z","v":0}

logger.fatal(12345);
// output: {"name":"your-node-svc","instance_id":"c5ade839-73a1-47a9-8552-a9417d0b8c09","env":"development","app_version":"0.0.1","hostname":"your-hostname","pid":34452,"level":60,"log_level":"FATAL","message":12345,"msg":"","time":"2019-06-13T09:59:36.228Z","v":0}
```