### PR TITLE
JSONLogger improvement

### DIFF
--- a/src/json_logger.ts
+++ b/src/json_logger.ts
@@ -57,7 +57,7 @@ export class JSONLogger implements ILogger {
 		]);
 	}
 
-	create_message(level: string, message?: any, ...optionalParams: any[]): {} {
+	create_message(level: string, message: any = '', optionalParams: any[] = []): {} {
 		let logMessage = {
 			log_level: level,
 		};
@@ -65,7 +65,7 @@ export class JSONLogger implements ILogger {
 		if (typeof message === "object") {
 			Object.assign(logMessage, message);
 		} else if (typeof message === "string") {
-			Object.assign(logMessage, {message: printf(message, optionalParams)});
+			Object.assign(logMessage, {message: printf(message, ...optionalParams)} );
 		} else {
 			Object.assign(logMessage, {message});
 		}


### PR DESCRIPTION
Added spread in printf to allow formatting for multiple optionalParams.

Example:
```javascript
logger.info('%s test %s', 'sending', 'message');
// output: {"name":"your-node-svc","instance_id":"c5ade839-73a1-47a9-8552-a9417d0b8c09","env":"development","app_version":"0.0.1","hostname":"your-hostname","pid":34452,"level":10,"log_level":"INFO","message":"sending test message","msg":"","time":"2019-06-13T09:59:36.227Z","v":0}
```